### PR TITLE
Add optional spatial filter to arcgis query

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If your ArcGIS endpoint is protected via SSL and requires particular client cert
 ```
 You can optionally pass a hostname to the `ssl_ignore_hostname` option to ignore hostname checking for that particular host.
 
-## ArcGIS.get(layer[,where="1 = 1", fields=[], count_only=False, srid='4326'])
+## ArcGIS.get(layer[,where="1 = 1", fields=[], count_only=False, srid='4326', input_geom_type=None, input_geom=None, input_srid=None, spatial_rel=None])
 
 Gets a single layer from the web service.
 
@@ -120,6 +120,21 @@ If `count_only` is specified, we return a simple count of the number of features
 >>> southeast_count = service.get(28, where="NAME IN ('Florida', 'Georgia', 'Alabama', 'South Carolina')", count_only=True)
 4
 ```
+
+Additionally, arguments can be supplied to include a spatial query when making a request using the `input_geom_type`, `input_geom`, `input_srid`, and `spatial_rel` arguments.
+
+```python
+>>> geojson = service.get(28)
+>>> input_geom_type = 'esriGeometryPolygon'
+>>> input_geom =  '{"rings":[[[-83.49609375,38.16911413556086],[-83.49609375,41.541477666790286],[-76.0693359375,41.541477666790286],[-76.0693359375,38.16911413556086],[-83.49609375,38.16911413556086]]],"hasZ":false,"hasM":false}'
+>>> input_srid = '4326'
+>>> spatial_rel = 'esriSpatialRelContains'
+>>> only_wv = service.get(28, where="NAME = 'West Virginia'", input_geom_type=input_geom_type, input_geom=input_geom, input_srid=input_srid, spatial_rel=spatial_rel)
+```
+
+`input_geom_type` must be a string and must be one of the available [geometry types](http://resources.arcgis.com/en/help/rest/apiref/index.html?relation.html) `esriGeometryPoint`, `esriGeometryMultipoint`, `esriGeometryPolyline`, `esriGeometryPolygon`, or `esriGeometryEnvelope`. The format of `input_geom` will depend on what the geometry type specified is. Additionally, [spatial relationship](http://resources.esri.com/help/9.3/arcgisserver/apis/soap/SOAP_esriGeometryRelationEnum.htm) must be specified and will determine the type of spatial query to be performed.
+
+Note - all arguments must be specified to perform a spatial query -- omission of one will cause a warning.
 
 ### ArcGIS.getMultiple(layers[, where="1 = 1", fields=[], srid='4326', layer_name_field=None])
 

--- a/arcgis/arcgis.py
+++ b/arcgis/arcgis.py
@@ -1,10 +1,14 @@
-import json
+import logging
+
 import requests
-import os
 
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.poolmanager import PoolManager
+
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
 
 
 class SSLIgnoreHostnameAdapter(HTTPAdapter):
@@ -152,8 +156,12 @@ class ArcGIS:
             'spatialRel': spatial_rel
         }
 
-        if all([input_srid, input_geom_type, input_geom]):
+        spatial_filter_params = [input_srid, input_geom_type, input_geom, spatial_rel]
+        if all(spatial_filter_params):
             params.update(geom_filter_params)
+
+        if not all(spatial_filter_params) and any(spatial_filter_params):
+            logger.warning('Ignoring spatial filter - not all parameters supplied')
 
         if self.token:
             params['token'] = self.token

--- a/arcgis/arcgis.py
+++ b/arcgis/arcgis.py
@@ -130,19 +130,31 @@ class ArcGIS:
             "geometry": geom_parser(obj.get('geometry'))
         }
 
-    def get_json(self, layer, where="1 = 1", fields=[], count_only=False, srid='4326'):
+    def get_json(self, layer, where="1 = 1", fields=[], count_only=False, srid='4326',
+                 input_geom_type=None, input_geom=None, input_srid=None, spatial_rel=None):
         """
         Gets the JSON file from ArcGIS
         """
         params = {
-                'where': where,
-                'outFields': ", ".join(fields),
-                'returnGeometry': True,
-                'outSR': srid,
-                'f': "pjson",
-                'orderByFields': self.object_id_field,
-                'returnCountOnly': count_only
-            }
+            'where': where,
+            'outFields': ", ".join(fields),
+            'returnGeometry': True,
+            'outSR': srid,
+            'f': "pjson",
+            'orderByFields': self.object_id_field,
+            'returnCountOnly': count_only
+        }
+
+        geom_filter_params = {
+            'inSR': input_srid,
+            'geometryType': input_geom_type,
+            'geometry': input_geom,
+            'spatialRel': spatial_rel
+        }
+
+        if all([input_srid, input_geom_type, input_geom]):
+            params.update(geom_filter_params)
+
         if self.token:
             params['token'] = self.token
         if self.geom_type:
@@ -173,7 +185,8 @@ class ArcGIS:
         descriptor = self.get_descriptor_for_layer(layer)
         return [field['name'] for field in descriptor['fields']]
 
-    def get(self, layer, where="1 = 1", fields=[], count_only=False, srid='4326'):
+    def get(self, layer, where="1 = 1", fields=[], count_only=False, srid='4326',
+                 input_geom_type=None, input_geom=None, input_srid=None, spatial_rel=None):
         """
         Gets a layer and returns it as honest to God GeoJSON.
 
@@ -187,7 +200,8 @@ class ArcGIS:
         # the KMZ mode. I'd rather be explicit.
         fields = fields or self.enumerate_layer_fields(layer)
 
-        jsobj = self.get_json(layer, where, fields, count_only, srid)
+        jsobj = self.get_json(layer, where, fields, count_only, srid,
+                              input_geom_type, input_geom, input_srid, spatial_rel)
 
         # Sometimes you just want to know how far there is to go.
         if count_only:
@@ -210,14 +224,17 @@ class ArcGIS:
             if base_where != "1 = 1" :
                 # If we have another WHERE filter we needed to tack that back on.
                 where += " AND %s" % base_where
-            jsobj = self.get_json(layer, where, fields, count_only, srid)
+            jsobj = self.get_json(layer, where, fields, count_only, srid,
+                                  input_geom_type, input_geom, input_srid, spatial_rel)
+
 
         return {
             'type': "FeatureCollection",
             'features': features
         }
 
-    def getMultiple(self, layers, where="1 = 1", fields=[], srid='4326', layer_name_field=None):
+    def getMultiple(self, layers, where="1 = 1", fields=[], srid='4326', layer_name_field=None,
+                    input_geom_type=None, input_geom=None, input_srid=None, spatial_rel=None):
         """
         Get a bunch of layers and concatenate them together into one. This is useful if you
         have a map with layers for, say, every year named stuff_2014, stuff_2013, stuff_2012. Etc.

--- a/tests.py
+++ b/tests.py
@@ -41,6 +41,19 @@ class ArcGISTest(unittest.TestCase):
         features = districts.getMultiple([4, 5], where="NOSALE>0", fields='OBJECTID,NOSALE')
         self.assertEqual(len(features.get('features')), 5)
 
+    def test_spatial_query(self):
+        districts = ArcGIS("http://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_Congressional_Districts/FeatureServer")
+        full_count = districts.get(0, count_only=True)
+        self.assertEqual(full_count, 437)
+
+        input_geom_type = 'esriGeometryPolygon'
+        # Roughly PA
+        input_geom = '{"rings":[[[-80.70556640625,39.223742741391305],[-80.70556640625,42.407234661551875],[-75.311279296875,42.407234661551875],[-75.311279296875,39.223742741391305],[-80.70556640625,39.223742741391305]]],"hasZ":false,"hasM":false}'
+        input_srid = '4326'
+        spatial_rel = 'esriSpatialRelContains'
+        filtered_count = districts.get(0, where="STATE_ABBR = 'PA'", count_only=True, input_geom_type=input_geom_type, input_geom=input_geom, input_srid=input_srid, spatial_rel=spatial_rel)
+        self.assertEqual(filtered_count, 10)
+        self.assertNotEqual(full_count, filtered_count)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit adds support for spatial filters for ArcGIS Server
requests. A few fields are required to do a spatial filter now:
- input_geom_type: an EsriGeometryType (see http://resources.arcgis.com/en/help/rest/apiref/index.html?relation.html)
- input_geom: valid json `string` for the defined geometry type
- input_srid: spatial reference identifier
- spatial_rel: spatial relationship query type (see http://resources.esri.com/help/9.3/arcgisserver/apis/soap/SOAP_esriGeometryRelationEnum.htm)

I'm not super satisfied with the API -- I think part 2 of this PR would add support for just passing in an arbitrary GEOS object and a spatial relationship to use and let the ArcGIS library constuct the proper query, but this allows for dealing with ArcGIS layers with null geometries by doing a simple polygon contains query
